### PR TITLE
[wip] Tripal integration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       POSTGRES_PASSWORD: password
 
   postgrest:
-    image: erasche/postgrest:latest
+    image: quay.io/erasche/postgrest:latest
     links:
       - "tripal_db:db"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     links:
         - apollo
         - galaxy
+        - tripal
     volumes:
         - "./nginx/conf:/etc/nginx/conf.d"
 
@@ -36,7 +37,7 @@ services:
       WEBAPOLLO_CHADO_DB_PASSWORD: password
       WEBAPOLLO_CHADO_DB_DRIVER: "org.postgresql.Driver"
       WEBAPOLLO_CHADO_DB_DIALECT: "org.hibernate.dialect.PostgresPlusDialect"
-      WEBAPOLLO_CHADO_DB_URI: "jdbc:postgresql://chado/postgres"
+      WEBAPOLLO_CHADO_DB_URI: "jdbc:postgresql://tripal_db/postgres"
     volumes_from:
         - "galaxy:ro"
 
@@ -48,7 +49,7 @@ services:
   postgrest:
     image: erasche/postgrest:latest
     links:
-      - "chado:db"
+      - "tripal_db:db"
     ports:
       - "8300:8000"
     environment:
@@ -69,31 +70,34 @@ services:
     environment:
       - POSTGRES_PASSWORD=password
     links:
-      - "chado:db"
+      - "tripal_db:db"
     ports:
       - "8500:8500"
 
-  chado:
+  tripal_db:
     image: erasche/chado:latest
     environment:
       - POSTGRES_PASSWORD=password
         # The default chado image would try to install the schema on first run,
         # we just want the tools to be available.
-      - INSTALL_CHADO_SCHEMA=1
-  #tripal:
-    #image: erasche/tripal:latest
-    #links:
-      #- chado:postgres
-    #volumes:
-      #- /var/www/html/sites
-      #- /var/www/private
-    #environment:
-      #UPLOAD_LIMIT: 20M
-      #MEMORY_LIMIT: 128M
-      #BASE_URL: "http://localhost:8080/tripal"
-      #BASE_URL_PROTO: "http://"
-      #DB_DRIVER: pgsql
-      #DB_NAME: postgres
-      #DB_HOST: postgres
-      #DB_PASS: password
-      #DB_USER: postgres
+      - INSTALL_CHADO_SCHEMA=0
+
+  tripal:
+    image: erasche/tripal:latest
+    links:
+      - tripal_db:postgres
+    volumes:
+      - /var/www/html/sites
+      - /var/www/private
+    environment:
+      UPLOAD_LIMIT: 20M
+      MEMORY_LIMIT: 128M
+      BASE_URL: "http://localhost:8080/tripal"
+      BASE_URL_PROTO: "http://"
+      # FIXME Deprecated ENV var added for compatibility: https://docs.docker.com/compose/link-env-deprecated/
+      POSTGRES_PORT_5432_TCP_ADDR: postgres
+      POSTGRES_PORT_5432_TCP_PORT: 5432
+      POSTGRES_PORT_5432_TCP: tcp://postgres:5432
+      POSTGRES_ENV_POSTGRES_PASSWORD: password
+    ports:
+      - "8080:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,9 +95,6 @@ services:
       BASE_URL: "http://localhost:8080/tripal"
       BASE_URL_PROTO: "http://"
       # FIXME Deprecated ENV var added for compatibility: https://docs.docker.com/compose/link-env-deprecated/
-      POSTGRES_PORT_5432_TCP_ADDR: postgres
-      POSTGRES_PORT_5432_TCP_PORT: 5432
-      POSTGRES_PORT_5432_TCP: tcp://postgres:5432
-      POSTGRES_ENV_POSTGRES_PASSWORD: password
+      DB_PASS: password
     ports:
       - "8080:80"

--- a/nginx/conf/default.conf
+++ b/nginx/conf/default.conf
@@ -11,6 +11,15 @@ server {
         proxy_pass       http://apollo:8080/apollo;
     }
 
+    location /tripal {
+        proxy_set_header X-Forwarded-Host        $host;
+        proxy_set_header X-Forwarded-Server      $host;
+        proxy_set_header X-Forwarded-For         $proxy_add_x_forwarded_for;
+
+        proxy_redirect   http://tripal/tripal      http://$http_host/tripal;
+        proxy_pass       http://tripal/tripal;
+    }
+
     location / {
         proxy_set_header X-Forwarded-Host        $host;
         proxy_set_header X-Forwarded-Server      $host;


### PR DESCRIPTION
Hi!
I have added the tripal service and the chado(-like) schema is now loaded by tripal to the renamed tripal_db service. I haven't tested extensively all the components yet though...

There are still a few problems:

- postgrest service fails to start, but it seems like the image has not been rebuilt lately, do you know why? The latest version in [github](https://github.com/erasche/docker-recipes/blob/master/postgrest/run.sh) should be ok I think
- I had to add the POSTGRES_PORT_5432_* variables for tripal because of https://docs.docker.com/compose/link-env-deprecated/. We could change it as you did for postgres, but I wonder if there is any preference between fixing it upstream or in a derived image (like postgrest)?
- chado-jbrowse-connector also fails with a "connection refused", I still have to find out why

Anthony