### PR TITLE
Add basic rest api for tripal

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,6 +113,8 @@ services:
       MEMORY_LIMIT: 128M
       BASE_URL: "http://localhost:8200/tripal"
       BASE_URL_PROTO: "http://"
+      TRIPAL_GIT_CLONE_MODULES: "https://github.com/abretaud/tripal_rest_api.git"
+      TRIPAL_ENABLE_MODULES: "tripal_rest_api"
     #ports:
       #- "8080:80"
 


### PR DESCRIPTION
A small module I have written that exposes a small REST API to submit tripal jobs.

And I have made a python lib and first scripts that uses it: https://github.com/abretaud/python-tripal

Once the galaxy wrappers will be written, it will allow us to load data in tripal directly from galaxy. For loading basic data like genes or sequences, I would prefer some universal chado loader, but some tripal modules are loading data in specific ways (e.g. tripal_analysis_blast module uses some custom tables), so I prefer to just let them do they work :)

I think I will write a todo list for tripal<->galaxy
